### PR TITLE
use serial number as a default file name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
+CFLAGS=-std=c99
+
 nfc-ltocm:	nfc-ltocm.o nfc-utils.o
 	$(CC) -o $@ $^ -lnfc


### PR DESCRIPTION
[Before]
If file name is not provided, then you will get a syntax error:

[root nfc-ltocm]# ./nfc-ltocm
./nfc-ltocm: read LTO-CM memory data to file
Syntax: ./nfc-ltocm filename

[After]
If file name is not provided, then use LTO-CM serial number as a file name. 

[root nfc-ltocm]$ ./nfc-ltocm
NFC reader: ACS / ACR122U PICC Interface opened
LTO REQUEST STANDARD: 00 01
Found LTO-CM tag with s/n 77:68:B4:07:AC
Reading LTO-CM data to file
[root nfc-ltocm]$ ls
7768B407.bin  Makefile  README.md  nfc-ltocm  nfc-ltocm.c  nfc-ltocm.o  nfc-utils.c  nfc-utils.h  nfc-utils.o

If file name is provided, then this will be used.