### PR TITLE
Bug fix: default file name

### DIFF
--- a/nfc-ltocm.c
+++ b/nfc-ltocm.c
@@ -243,7 +243,7 @@ int main(int argc, char **argv)
 	}
 	printf("Found LTO-CM tag with s/n %02X:%02X:%02X:%02X:%02X\n",
 			abtRx[0], abtRx[1], abtRx[2], abtRx[3], abtRx[4]);
-	char default_filename[12];
+	char default_filename[13];
 	sprintf(default_filename, "%02X%02X%02X%02X.bin", abtRx[0], abtRx[1], abtRx[2], abtRx[3]);
 
 	// Check the serial number's validity


### PR DESCRIPTION
The length of default_filename must be 13, not 12. 8 bytes for CM serial number + 4 bytes for ".bin" and + 1 byte for null-terminated, total 13. 