### PR TITLE
Add support for Type 3 LTO-CM

### DIFF
--- a/nfc-ltocm.c
+++ b/nfc-ltocm.c
@@ -197,7 +197,7 @@ bool ltocm_readblk_ext(size_t block, uint8_t *retReadBlk, int *retLenReadBlk)
 	readBlockCmd[1] = block & 0xff;
 	readBlockCmd[2] = (block >>8) & 0xff;
 
-	iso14443a_crc_append(readBlockCmd, sizeof(LTOCM_READ_BLOCK_EXT)-2);
+	iso14443a_crc_append(readBlockCmd, 3);
 	
 	if (!transmit_bytes(readBlockCmd, sizeof(readBlockCmd)))
 		return false;
@@ -388,20 +388,19 @@ int main(int argc, char **argv)
 	for (size_t block = 0; block < numLTOCMBlocks; block++) {
 
 		// read the first half of the block
-		if (numLTOCMBlocks<=255)
-		{//Use old function that uses one byte for block address
-		        if (!ltocm_readblk(block, &retReadBlk[0], &retLenReadBlk)) {
-			        printf("Error: error with READ BLOCK command, block=%zu of %zu\n", block, numLTOCMBlocks-1);
-			        returncode = EXIT_FAILURE;
-			        goto err_exit;
-		        }
-                } else { //Use new function that uses 2 bytes for block address
-		        if (!ltocm_readblk_ext(block, &retReadBlk[0], &retLenReadBlk)) {
-			        printf("Error: error with READ BLOCK command, block=%zu of %zu\n", block, numLTOCMBlocks-1);
-			        returncode = EXIT_FAILURE;
-			        goto err_exit;
-		        }
-                }
+		if (numLTOCMBlocks <= 255) {
+			if (!ltocm_readblk(block, &retReadBlk[0], &retLenReadBlk)) {
+				printf("Error: error with READ BLOCK command, block=%zu of %zu\n", block, numLTOCMBlocks-1);
+				returncode = EXIT_FAILURE;
+				goto err_exit;
+			}
+		} else {
+			if (!ltocm_readblk_ext(block, &retReadBlk[0], &retLenReadBlk)) {
+				printf("Error: error with READ BLOCK command, block=%zu of %zu\n", block, numLTOCMBlocks-1);
+				returncode = EXIT_FAILURE;
+				goto err_exit;
+			}
+		}
 		// check the byte count and response bytes
 		if ((retLenReadBlk == 1) && (retReadBlk[0] == LTOCM_NACK)) {
 			printf("Error: READ BLOCK %zu (of %zu) failed, NACK\n", block, numLTOCMBlocks-1);

--- a/nfc-ltocm.h
+++ b/nfc-ltocm.h
@@ -5,6 +5,6 @@ bool ltocm_req_std(uint8_t *ltoStandard);
 bool ltocm_req_serial(uint8_t *serialNum, int *serialNumLen);
 bool ltocm_select(uint8_t *serialNum, uint8_t *retSelect, int *retLenSelect);
 bool ltocm_readblk(size_t block, uint8_t *retReadBlk, int *retLenReadBlk);
+bool ltocm_readblk_ext(size_t block, uint8_t *retReadBlk, int *retLenReadBlk);
 bool ltocm_readblkcnt(uint8_t *retReadBlk, int *retLenReadBlk);
-
 #endif


### PR DESCRIPTION
I found this code commented out in the Proxmark repo. 

It generates a 16KB file that parses successfully with lto_analyzer, which throws a error if I only feed in only the first 254 blocks of the chip.